### PR TITLE
Rework to Octoprint-like implementation, plus Camera and API additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Custom integration to monitor your **Minton BeagleCam** (3D printer camera) insi
 
 ## 📸 Features
 
-- ✅ Connects to your BeagleCam via its local IP address
-- ✅ Authenticates using your printer's username and password
-- ✅ Polls **print status** (`cmd: 318`)
-- ✅ Polls **temperature data** (`cmd: 302`)
-- ✅ Shows data in a **single sensor** with rich attributes:
+- ✅ Connects to your BeagleCam via its local IP address or hostname
+- ✅ Authenticates using your configured username and password
+- ✅ Polls **camera information**, **print status**, **temperature data**
+- ✅ Surfaces a camera feed from the BeagleCam, suitable for dashboards and AI processing
+- ✅ Many sensors available, resembling OctoPrint's available sensors:
+  - Printer status (idle, printing, paused, completed)
   - File name
   - Progress (%)
-  - Time left
+  - Job start time and estimated completion time
   - Nozzle/bed temps (current and target)
 - ✅ Real-time updates every 10 seconds
 - ✅ Fails gracefully and reconnects
@@ -41,27 +42,27 @@ Until this is added to the default HACS list, install manually:
 2. Click **"Add Integration"**
 3. Search for **"BeagleCam"**
 4. Enter:
-   - IP Address
+   - IP Address or Hostname
    - Username
    - Password
 
-Home Assistant will validate the connection using `cmd: 312` (`get_prconnectstate`).
+Home Assistant will validate the connection using `cmd: 100` (`check_user`).
 
 ---
 
 ## 🧪 Entity Example
 
-After setup, you'll see a single sensor entity:
+After setup, you'll see a single BeagleCam device with 10 sensor entities, including:
 
-**Entity ID**: `sensor.beaglecam_print_status`  
-**State**: Current print progress (e.g., `42`)  
-**Attributes**:
+- `binary_sensor.beaglecam_printing`: On/Off if printing
+- `sensor.beaglecam_current_state`: Current printer state (idle, printing, paused, completed)
+- `sensor.beaglecam_current_file`: Current file name
+- `sensor.beaglecam_job_percentage`: Print progress percentage
+- `sensor.beaglecam_job_start_time`: Start time of current job
+- `sensor.beaglecam_job_estimated_finish_time`: Estimated time of completion
+- `sensor.beaglecam_actual_nozzle_temp`: Current nozzle temperature
+- `sensor.beaglecam_actual_bed_temp`: Current bed temperature
+- `sensor.beaglecam_target_nozzle_temperature`: Target nozzle temperature
+- `sensor.beaglecam_target_bed_temperature`: Target bed temperature
 
-```yaml
-file_name: benchy.gcode
-progress: 42
-time_left: 1680
-tempture_noz: 205
-tempture_bed: 60
-des_tempture_noz: 210
-des_tempture_bed: 60
+Plus, a camera entity: `camera.beaglecam_camera`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://hacs.xyz)
 
-Custom integration to monitor your **Minton BeagleCam** (3D printer camera) inside [Home Assistant](https://www.home-assistant.io/).
+Custom integration to monitor your **Mintion BeagleCam** (3D printer camera) inside [Home Assistant](https://www.home-assistant.io/).
 
 ---
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
-    session = async_get_clientsession(hass),
+    session = async_get_clientsession(hass)
 
     api = BeagleCamAPI(
         entry.data["ip_address"],

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -48,10 +48,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         except HTTPError as httperr:
             _LOGGER.warning("BeagleCam HTTP error: %s status: %s reason: %s", httperr, httperr.status, httperr.reason)
-            raise UpdateFailed(f"Data fetch failed: {httperr}")
+            raise UpdateFailed(f"Data fetch failed: {httperr}") from httperr
         except Exception as err:
             _LOGGER.warning("BeagleCam polling error: %s", err)
-            raise UpdateFailed(f"Data fetch failed: {err}")
+            raise UpdateFailed(f"Data fetch failed: {err}") from err
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -21,8 +21,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async_get_clientsession(hass),
     )
 
-    cam_info = await api.get_info()
-
     async def async_update_data():
         try:
             try:
@@ -35,12 +33,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             # Printer is online – proceed with normal status polling
             print_status = await api.get_print_status()
             temp_status = await api.get_temperature_status()
+            cam_info = await api.get_info()
 
             # Merge API responses
             combined = {
                 **{k: v for k, v in print_status.items() if k != "cmd"},
                 **{k: v for k, v in temp_status.items() if k != "cmd"},
-                **{k: v for k, v in connection.items() if k not in ("cmd", "result")}
+                **{k: v for k, v in connection.items() if k not in ("cmd", "result")},
+                **{k: v for k, v in cam_info.items() if k not in ("cmd", "result")},
             }
 
             _LOGGER.debug("Combined BeagleCam data: %s", combined)
@@ -63,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {k: v for k, v in cam_info.items() if k not in ("cmd", "result")})
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform, CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback, Event, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry
@@ -23,9 +23,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     session = async_get_clientsession(hass)
 
     api = BeagleCamAPI(
-        entry.data["ip_address"],
-        entry.data["username"],
-        entry.data["password"],
+        entry.data[CONF_HOST],
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
         session
     )
 
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         "api": api,
     }
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def async_printer_connect(call: ServiceCall) -> None:
         """Connect to a printer."""

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -2,8 +2,8 @@
 from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform, CONF_HOST, CONF_USERNAME, CONF_PASSWORD
-from homeassistant.core import HomeAssistant, callback, Event, ServiceCall
+from homeassistant.const import CONF_DEVICE_ID, Platform, CONF_HOST, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -30,16 +30,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         session
     )
 
-    @callback
-    def _async_close_websession(event: Event | None = None) -> None:
-        """Close websession."""
-        session.detach()
-
-    entry.async_on_unload(_async_close_websession)
-    entry.async_on_unload(
-        hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_close_websession)
-    )
-
     bc_coordinator = BeagleCamDataUpdateCoordinator(hass, api, entry, DEFAULT_SCAN_INTERVAL)
 
     await bc_coordinator.async_config_entry_first_refresh()
@@ -47,7 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": bc_coordinator,
     }
-    #TODO? entry.unique_id = hass.data[DOMAIN][entry.entry_id]["camera"]["p2pid"]
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -48,6 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         "coordinator": bc_coordinator,
         "api": api,
     }
+    entry.unique_id = hass.data[DOMAIN][entry.entry_id].data["camera"]["p2pid"]
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,79 +1,74 @@
-import asyncio
-from datetime import timedelta
+from exceptions import ServiceValidationError
+from typing import cast
 
-from aiohttp.web_exceptions import HTTPError
+from coordinator import BeagleCamDataUpdateCoordinator
+from helpers import device_registry
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform
+from homeassistant.core import HomeAssistant, callback, Event, ServiceCall
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, DEFAULT_SCAN_INTERVAL
+from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, SERVICE_PR_CONNECT
 from .beaglecam_api import BeagleCamAPI
 
 import logging
+
+PLATFORMS = [Platform.SENSOR, Platform.CAMERA]
+
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    hass.data.setdefault(DOMAIN, {})
+    session = async_get_clientsession(hass),
+
     api = BeagleCamAPI(
         entry.data["ip_address"],
         entry.data["username"],
         entry.data["password"],
-        async_get_clientsession(hass),
+        session
     )
 
-    async def async_update_data():
-        try:
-            try:
-                connection = await api.get_connection_state()
-            except Exception as err:
-                _LOGGER.debug("BeagleCam is offline. Polling again in 300s.")
-                await asyncio.sleep(300)  # throttle manually
-                return None
+    @callback
+    def _async_close_websession(event: Event | None = None) -> None:
+        """Close websession."""
+        session.detach()
 
-            # Printer is online – proceed with normal status polling
-            print_status = await api.get_print_status()
-            temp_status = await api.get_temperature_status()
-            cam_info = await api.get_info()
-
-            # Merge API responses
-            combined = {
-                **{k: v for k, v in print_status.items() if k != "cmd"},
-                **{k: v for k, v in temp_status.items() if k != "cmd"},
-                **{k: v for k, v in connection.items() if k not in ("cmd", "result")},
-                **{k: v for k, v in cam_info.items() if k not in ("cmd", "result")},
-            }
-
-            _LOGGER.debug("Combined BeagleCam data: %s", combined)
-            return combined
-
-        except HTTPError as httperr:
-            _LOGGER.warning("BeagleCam HTTP error: %s status: %s reason: %s", httperr, httperr.status, httperr.reason)
-            raise UpdateFailed(f"Data fetch failed: {httperr}") from httperr
-        except Exception as err:
-            _LOGGER.warning("BeagleCam polling error: %s", err)
-            raise UpdateFailed(f"Data fetch failed: {err}") from err
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="beaglecam",
-        update_method=async_update_data,
-        update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+    entry.async_on_unload(_async_close_websession)
+    entry.async_on_unload(
+        hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_close_websession)
     )
 
-    await coordinator.async_config_entry_first_refresh()
+    bc_coordinator = BeagleCamDataUpdateCoordinator(hass, api, entry, DEFAULT_SCAN_INTERVAL)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    await bc_coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "coordinator": coordinator,
+        "api": api,
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])
 
+    async def async_printer_connect(call: ServiceCall) -> None:
+        """Connect to a printer."""
+        client = async_get_client_for_service_call(hass, call)
+        await client.connect_printer()
+
+    if not hass.services.has_service(DOMAIN, SERVICE_PR_CONNECT):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_PR_CONNECT,
+            async_printer_connect
+        )
+
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Unload any platforms this integration sets up, e.g. sensors
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor", "camera"])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
         # Clean up stored data
@@ -81,7 +76,29 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return unload_ok
 
+
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload a config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
+
+
+def async_get_client_for_service_call(
+        hass: HomeAssistant, call: ServiceCall
+) -> BeagleCamAPI:
+    """Get the client related to a service call (by device ID)."""
+    device_id = call.data[CONF_DEVICE_ID]
+    device_reg = device_registry.async_get(hass)
+
+    if device_entry := device_reg.async_get(device_id):
+        for entry_id in device_entry.config_entries:
+            if data := hass.data[DOMAIN].get(entry_id):
+                return cast(BeagleCamAPI, data["api"])
+
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="missing_client",
+        translation_placeholders={
+            "device_id": device_id,
+        },
+    )

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,4 +1,3 @@
-from exceptions import ServiceValidationError
 from typing import cast
 
 from coordinator import BeagleCamDataUpdateCoordinator
@@ -6,6 +5,7 @@ from helpers import device_registry
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform
 from homeassistant.core import HomeAssistant, callback, Event, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, SERVICE_PR_CONNECT

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,6 +1,5 @@
 from typing import cast
 
-from coordinator import BeagleCamDataUpdateCoordinator
 from helpers import device_registry
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform
@@ -8,8 +7,9 @@ from homeassistant.core import HomeAssistant, callback, Event, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, SERVICE_PR_CONNECT
 from .beaglecam_api import BeagleCamAPI
+from .const import DOMAIN, DEFAULT_SCAN_INTERVAL, SERVICE_PR_CONNECT
+from .coordinator import BeagleCamDataUpdateCoordinator
 
 import logging
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -14,7 +14,7 @@ from .coordinator import BeagleCamDataUpdateCoordinator
 
 import logging
 
-PLATFORMS = [Platform.SENSOR, Platform.CAMERA]
+PLATFORMS = [Platform.SENSOR, Platform.CAMERA, Platform.BINARY_SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await bc_coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {
-        "coordinator": coordinator,
+        "coordinator": bc_coordinator,
         "api": api,
     }
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -63,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, **{k: v for k, v in cam_info.items() if k not in ("cmd", "result")})
+    hass.data.setdefault(DOMAIN, {k: v for k, v in cam_info.items() if k not in ("cmd", "result")})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -21,6 +21,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async_get_clientsession(hass),
     )
 
+    cam_info = await api.get_info()
+
     async def async_update_data():
         try:
             try:
@@ -31,13 +33,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 return None
 
             # Printer is online – proceed with normal status polling
-            cam_info = await api.get_info()
             print_status = await api.get_print_status()
             temp_status = await api.get_temperature_status()
 
             # Merge API responses
             combined = {
-                **{k: v for k, v in cam_info.items() if k not in ("cmd", "result")},
                 **{k: v for k, v in print_status.items() if k != "cmd"},
                 **{k: v for k, v in temp_status.items() if k != "cmd"},
                 **{k: v for k, v in connection.items() if k not in ("cmd", "result")}
@@ -63,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
+    hass.data.setdefault(DOMAIN, **{k: v for k, v in cam_info.items() if k not in ("cmd", "result")})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         "coordinator": bc_coordinator,
         "api": api,
     }
-    entry.unique_id = hass.data[DOMAIN][entry.entry_id].data["camera"]["p2pid"]
+    #entry.unique_id = hass.data[DOMAIN][entry.entry_id]["camera"]["p2pid"]
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -29,11 +29,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 return None
 
             # Printer is online – proceed with normal status polling
+            cam_info = await api.get_info()
             print_status = await api.get_print_status()
             temp_status = await api.get_temperature_status()
 
             # Merge API responses
             combined = {
+                **{k: v for k, v in cam_info.items() if k not in ("cmd", "result")},
                 **{k: v for k, v in print_status.items() if k != "cmd"},
                 **{k: v for k, v in temp_status.items() if k != "cmd"},
                 **{k: v for k, v in connection.items() if k not in ("cmd", "result")}

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,3 +1,4 @@
+
 from typing import cast
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -46,9 +46,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": bc_coordinator,
-        "api": api,
     }
-    #entry.unique_id = hass.data[DOMAIN][entry.entry_id]["camera"]["p2pid"]
+    #TODO? entry.unique_id = hass.data[DOMAIN][entry.entry_id]["camera"]["p2pid"]
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -63,6 +62,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             SERVICE_PR_CONNECT,
             async_printer_connect
         )
+
+    _LOGGER.debug("BeagleCam integration setup complete for entry %s: %s", entry.entry_id, entry)
 
     return True
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -18,8 +18,10 @@ PLATFORMS = [Platform.SENSOR, Platform.CAMERA, Platform.BINARY_SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
+"""The BeagleCam integration."""
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up BeagleCam from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     session = async_get_clientsession(hass)
 

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,5 +1,7 @@
 import asyncio
 from datetime import timedelta
+
+from aiohttp.web_exceptions import HTTPError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -44,6 +46,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             _LOGGER.debug("Combined BeagleCam data: %s", combined)
             return combined
 
+        except HTTPError as httperr:
+            _LOGGER.warning("BeagleCam HTTP error: %s status: %s reason: %s", httperr, httperr.status, httperr.reason)
+            raise UpdateFailed(f"Data fetch failed: {httperr}")
         except Exception as err:
             _LOGGER.warning("BeagleCam polling error: %s", err)
             raise UpdateFailed(f"Data fetch failed: {err}")

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -1,10 +1,10 @@
 from typing import cast
 
-from helpers import device_registry
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_DEVICE_ID, Platform
 from homeassistant.core import HomeAssistant, callback, Event, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .beaglecam_api import BeagleCamAPI

--- a/custom_components/beaglecam/__init__.py
+++ b/custom_components/beaglecam/__init__.py
@@ -66,14 +66,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "camera"])
 
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Unload any platforms this integration sets up, e.g. sensors
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor"])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor", "camera"])
 
     if unload_ok:
         # Clean up stored data

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import aiohttp
 import logging
 
@@ -5,19 +7,27 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class BeagleCamAPI:
-    def __init__(self, ip, username, password, session):
+    def __init__(self, ip: str, username: str, password: str, session: aiohttp.ClientSession):
         self._url = f"http://{ip}/set3DPiCmd"
         self._username = username
         self._password = password
         self._session = session
 
         # Add counters for logging throttling
-        self._call_counts = {
+        self._call_counts = defaultdict(int, **{
             "connection_state": 0,
             "print_status": 0,
             "temperature_status": 0,
-            "info_get": 0,
-        }
+        })
+
+    async def _do_post(self, payload: dict, debug_key: str):
+        async with self._session.post(self._url, json=payload) as response:
+            response.raise_for_status()
+            response_json = await response.json()
+            self._call_counts[debug_key] += 1
+            if self._call_counts[debug_key] % 10 == 0:
+                _LOGGER.debug("BeagleCamAPI.%s response: %s", debug_key, response_json)
+            return response_json
 
     async def get_connection_state(self):
         """
@@ -47,13 +57,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        async with self._session.post(self._url, json=payload) as response:
-            response.raise_for_status()
-            responseJson = await response.json()
-            self._call_counts["connection_state"] += 1
-            if self._call_counts["connection_state"] % 10 == 0:
-                _LOGGER.debug("BeagleCamAPI.get_connection_state response: %s", responseJson)
-            return responseJson
+        return self._do_post(payload, "connection_state")
 
     async def get_print_status(self):
         """Poll printer status using cmd 318.
@@ -77,13 +81,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        async with self._session.post(self._url, json=payload) as response:
-            response.raise_for_status()
-            responseJson = await response.json()
-            self._call_counts["print_status"] += 1
-            if self._call_counts["print_status"] % 10 == 0:
-                _LOGGER.debug("BeagleCamAPI.get_print_status response: %s", responseJson)
-            return responseJson
+        return self._do_post(payload, "print_status")
 
     async def get_temperature_status(self):
         """
@@ -104,18 +102,10 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-
-        async with self._session.post(self._url, json=payload) as response:
-            response.raise_for_status()
-            responseJson = await response.json()
-            self._call_counts["temperature_status"] += 1
-            if self._call_counts["temperature_status"] % 10 == 0:
-                _LOGGER.debug("BeagleCamAPI.get_temperature_status response: %s", responseJson)
-            return responseJson
+        return self._do_post(payload, "temperature_status")
 
     async def get_info(self):
         """
-
         API Example Return:
         {
             "cmd":101,
@@ -144,11 +134,1291 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
+        return self._do_post(payload, payload["pro"])
 
-        async with self._session.post(self._url, json=payload) as response:
-            response.raise_for_status()
-            responseJson = await response.json()
-            self._call_counts["info_get"] += 1
-            if self._call_counts["info_get"] % 10 == 0:
-                _LOGGER.debug("BeagleCamAPI.info_get response: %s", responseJson)
-            return responseJson
+    async def get_baudrate(self):
+        """
+        Example API Return:
+        {
+            "cmd":251,
+            "result":0,
+            "baudrate":"115200:8:0:1",
+            "ttyUSBList":[{"ttyName":"/dev/ttyACM0"}]
+        }
+        """
+        payload = {
+            "cmd": 251,
+            "pro": "get_baudrate",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_tlv_params(self):
+        """
+        Example API Return:
+        `{
+            "cmd":337,
+            "result":0,
+            "enable":2,
+            "maxx":250,
+            "maxy":210,
+            "maxz":210,
+            "video_type":"H264",
+            "fps":15,
+            "min_inr_secs":5,
+            "duration_tlv":0,
+            "uv_layers":0,
+            "prex":2,
+            "prey":208,
+            "prez":4,
+            "xymove_speed":170,
+            "zmove_speed":12,
+            "move_delay_ms":500,
+            "retract_length":5,
+            "retract_speed":25,
+            "extrude_length":5,
+            "extrude_speed":25,
+            "extra_filling":0.100000,
+            "filling_speed":25
+        }`
+        """
+        payload = {
+            "cmd": 337,
+            "pro": "get_tlv_params",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_model(self):
+        """
+        Example API Return:
+        {
+          "cmd": 253,
+          "version": "2.1",
+          "result": 0,
+          "machineType": ["Marlin", "Klipper"],
+          "machineTypeSelected": "Marlin",
+          "KlipperObj": {
+            "PrinterSelected": "",
+            "ModelsList": [
+              {
+                "protocol": "moonraker",
+                "webClient": [
+                  "mainsail",
+                  "fluidd"
+                ],
+                "url": "ws://ip:80/websocket",
+                "accessToken": "",
+                "apiKey": ""
+              }
+            ]
+          },
+          "selected": {  // One selection from the BrandModelList below, collapsed into a single level.
+            "brand": "Prusa",
+            "model": "i3 MK3S+",
+            "size": "250x210x210mm",
+            "category": "CoreXY",
+            "usbpower": "true"
+          },
+          "BrandModelList": [
+            {
+              "name": "ANYCUBIC",
+              "data": [
+                {
+                  "typename": "Mega S",
+                  "size": "210x210x205mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Mega Pro",
+                  "size": "210x210x205mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Mega SE",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Mega Zero 2.0",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Mega X",
+                  "size": "300x300x305mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Vyper",
+                  "size": "245x245x260mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra2",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra 2 Neo",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra Go",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra Neo",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra Plus",
+                  "size": "300x300x350mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Kobra Max",
+                  "size": "400x400x450mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Chiron",
+                  "size": "400x400x450mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Anet",
+              "data": [
+                {
+                  "typename": "ET5X",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                },
+                {
+                  "typename": "A8",
+                  "size": "220x220x240mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                }
+              ]
+            },
+            {
+              "name": "Artillery",
+              "data": [
+                {
+                  "typename": "SW X1",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SW X2",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Genius",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Genius Pro",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Hornet",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "BIQU",
+              "data": [
+                {
+                  "typename": "BX",
+                  "size": "250x250x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Creality",
+              "data": [
+                {
+                  "typename": "Ender-2 Pro",
+                  "size": "165x165x180mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 Pro",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 V2",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 Neo",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 V2 Neo",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 S1",
+                  "size": "220x220x270mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 S1 Pro",
+                  "size": "220x220x270mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 S1 Plus",
+                  "size": "300x300x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 Max",
+                  "size": "300x300x340mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 Max Neo",
+                  "size": "300x300x320mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-3 V3 SE",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-5",
+                  "size": "220x220x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-5 Pro",
+                  "size": "220x220x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-5 Plus",
+                  "size": "350x350x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ender-7",
+                  "size": "250x250x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-5 Pro",
+                  "size": "300x225x380mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-6 SE",
+                  "size": "235x235x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10 S",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10 V2",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10 V3",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10 Smart*",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10 Smart Pro*",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-10 Max",
+                  "size": "450x450x470mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR10 S5",
+                  "size": "500x500x500mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR-20 Pro",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "CR 200B",
+                  "size": "200x200x200mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "ELEGOO",
+              "data": [
+                {
+                  "typename": "Neptune 2",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Neptune 2D",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Neptune 2S",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Neptune 3",
+                  "size": "220x220x280mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Neptune 3 Pro",
+                  "size": "225x225x280mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Neptune 3 Plus",
+                  "size": "320x320x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Neptune 3 Max",
+                  "size": "420x420x500mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Eryone",
+              "data": [
+                {
+                  "typename": "ER-20",
+                  "size": "250x220x200mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                }
+              ]
+            },
+            {
+              "name": "Flsun",
+              "data": [
+                {
+                  "typename": "Super Race",
+                  "size": "260x260x330mm",
+                  "category": "Delta",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Flying Bear",
+              "data": [
+                {
+                  "typename": "Ghost 5",
+                  "size": "255x210x200mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Ghost 6",
+                  "size": "255x210x210mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Reborn 1",
+                  "size": "350x310x340mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Fokoos",
+              "data": [
+                {
+                  "typename": "ODIN-5 F3",
+                  "size": "235x235x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Geeetech",
+              "data": [
+                {
+                  "typename": "Mizar S",
+                  "size": "255x255x260mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "A20",
+                  "size": "250x250x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "A20M",
+                  "size": "250x250x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "i3 Pro",
+                  "size": "200x200x180mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Hellbot",
+              "data": [
+                {
+                  "typename": "Magna 2 230",
+                  "size": "230x230x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magna 2 300",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magna 2 500",
+                  "size": "500x500x500mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magna SE",
+                  "size": "230x230x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magna SE PRO",
+                  "size": "230x230x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magna SE 300",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Hidra*",
+                  "size": "230x230x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Hidra Plus*",
+                  "size": "300x300x350mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "iSUN3D",
+              "data": [
+                {
+                  "typename": "iSUN_FLX3",
+                  "size": "200x350x200mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "JGAURORA",
+              "data": [
+                {
+                  "typename": "A5S",
+                  "size": "305x305x320mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Kingroon",
+              "data": [
+                {
+                  "typename": "KP3S",
+                  "size": "180x180x180mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "KP3S Pro",
+                  "size": "210x210x200mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "KP3S Pro S1",
+                  "size": "200x200x200mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Kywoo",
+              "data": [
+                {
+                  "typename": "Tycoon",
+                  "size": "240x240x230mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Tycoon Slim",
+                  "size": "240x240x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Tycoon Max",
+                  "size": "300x300x230mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Longer",
+              "data": [
+                {
+                  "typename": "LK4 Pro",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "LK5 Pro",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Mingda",
+              "data": [
+                {
+                  "typename": "Magician X",
+                  "size": "230x230x260mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magician Pro",
+                  "size": "400x400x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Magician Max",
+                  "size": "320x320x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Monoprice",
+              "data": [
+                {
+                  "typename": "Mini Delta",
+                  "size": "110x110x120mm",
+                  "category": "Delta",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Mini Select V2",
+                  "size": "120x120x120mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Prusa",
+              "data": [
+                {
+                  "typename": "i3 MK3S+",
+                  "size": "250x210x210mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                },
+                {
+                  "typename": "i3 MK3S+ & MMU2/MMU2S/MMU3",
+                  "size": "250x210x210mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                },
+                {
+                  "typename": "MK4",
+                  "size": "250x210x220mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                },
+                {
+                  "typename": "MK4 & MMU2/MMU2S/MMU3",
+                  "size": "250x210x220mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                },
+                {
+                  "typename": "MINI+",
+                  "size": "180x180x180mm",
+                  "category": "CoreXY",
+                  "usbpower": "true"
+                }
+              ]
+            },
+            {
+              "name": "Snapmaker",
+              "data": [
+                {
+                  "typename": "A250T",
+                  "size": "230x250x235mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "A350T",
+                  "size": "320x350x330mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Sovol",
+              "data": [
+                {
+                  "typename": "SV01",
+                  "size": "280x240x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SV01 Pro",
+                  "size": "280x240x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SV02",
+                  "size": "280x240x300mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SV03",
+                  "size": "350x350x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SV04",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SV06",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SV06 Plus",
+                  "size": "300x300x340mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Sunlu",
+              "data": [
+                {
+                  "typename": "S8 Plus",
+                  "size": "310x310x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Terminator 3",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Tenlog",
+              "data": [
+                {
+                  "typename": "Hands 2",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "TL-D3 Pro",
+                  "size": "300x300x350mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Tevo",
+              "data": [
+                {
+                  "typename": "HYDRA",
+                  "size": "305x305x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Two Trees",
+              "data": [
+                {
+                  "typename": "BLU-3",
+                  "size": "235x235x280mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "BLU-5",
+                  "size": "300x300x400mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SP-3",
+                  "size": "220x220x220mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "SP-5",
+                  "size": "300x300x330mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Tronxy",
+              "data": [
+                {
+                  "typename": "X2",
+                  "size": "220x220x220mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Voxelab",
+              "data": [
+                {
+                  "typename": "Aquila",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Aquila C2",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Aquila X2",
+                  "size": "220x220x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Aquila S2",
+                  "size": "220x220x240mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                },
+                {
+                  "typename": "Aquila D1",
+                  "size": "235x235x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Wanhao",
+              "data": [
+                {
+                  "typename": "SD12 230",
+                  "size": "230x230x250mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            },
+            {
+              "name": "Wizmaker",
+              "data": [
+                {
+                  "typename": "P1",
+                  "size": "220x220x265mm",
+                  "category": "CoreXY",
+                  "usbpower": "false"
+                }
+              ]
+            }
+          ]
+        }
+        )
+        """
+        payload = {
+            "cmd": 253,
+            "pro": "get_model",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_osd(self):
+        """
+        Example API Return:
+        {
+            "cmd":171,
+            "result":0,
+            "timepos":4
+        }
+        """
+        payload = {
+            "cmd": 171,
+            "pro": "osd_get",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_video_mode(self):
+        """
+        Example API Return:
+        {
+            "cmd":135,
+            "result":0,
+            "video_mode":0
+        }
+        """
+        payload = {
+            "cmd": 135,
+            "pro": "video_mode_get",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def update_check(self):
+        """
+        Example API Return:
+        {
+            "cmd":219,
+            "result":0,
+            "curVersion":"1.2.9",
+            "ota_info": {
+                "ForceUpdateflag":"0",
+                "HARDWARE":"BeagleV2_H1.0",
+                "SWversion":"1.2.9",
+                "VersionIntro":"<br>- Fixed the bug that Klipper printer connection failure on some accounts; <br>- Add more details on Klipper printer connection and status;",
+                "FirmwareUrl":"https://beaglefirmware.oss-us-west-1.aliyuncs.com/BeagleV2/firmware_BeagleV2_kernel_system_1.2.9.bin"
+            }
+        }
+        """
+        payload = {
+            "cmd": 219,
+            "pro": "update_check",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_timelapse_videos(self):
+        """
+        Example API Return:
+        {
+            "cmd": 335,
+            "result": 0,
+            "count": 116, // total file count
+            "filesList": [
+                {
+                    "name": "20230807_052949_h264.mp4",
+                    "len": "12972K",
+                    "time": "2023/08/07 11:12:48"
+                },
+                ...,
+            ]
+        }
+
+        Video URLs are constructed as:
+            `http://<beaglecam_ip>/mmc/tlv/<filename>`
+        """
+        payload = {
+            "cmd": 335,
+            "pro": "pri_file",
+            "operate_cmd": 120,
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def connect_printer(self):
+        """
+        Initiate connection to the printer. This method may take a long time if the printer is not available.
+
+        Example API Return:
+        {
+            "cmd":310,
+            "result":0
+        }
+        """
+        payload = {
+            "cmd": 310,
+            "pro": "pr_connect",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def disconnect_printer(self):
+        """
+        Disconnect from the printer.
+
+        Example API Return:
+        {
+            "cmd":311,
+            "result":0
+        }
+        """
+        payload = {
+            "cmd": 311,
+            "pro": "pr_disconnect",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_print_files(self):
+        """
+        Example API Return:
+        {
+            "cmd": 320,
+            "result": 0,
+            "count": 24,
+            "filesList": [
+                {
+                    "name": "reprack_led_clip_v1_0.6n_0.2mm_PETG_MK3S_33m.gcode",
+                    "len": "1453K",
+                    "time": "2025/07/08 03:04:38"
+                },
+                ...,
+            ],
+        }
+
+        Gcode file URLs are constructed as:
+            `http://<beaglecam_ip>/mmc/<filename>`
+        """
+        payload = {
+            "cmd": 320,
+            "pro": "pri_file",
+            "operate_cmd": 120,
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_temperature_log(self):
+        """
+        Example API Return:
+        {
+            "cmd":330,
+            "result":0,
+            "count":3,
+            "filesList": [
+                {
+                    "name":"20251109_132547.tlog",
+                    "len":"25K",
+                    "time":"2025/11/09 13:55:47"
+                },
+                {
+                    "name":"20251109_135550.tlog",
+                    "len":"1K",
+                    "time":"2025/11/09 13:56:57"
+                },
+                {
+                    "name":"20251110_100935.tlog",
+                    "len":"11K",
+                    "time":"2025/11/10 10:23:05"
+                }
+            ]
+        }
+
+        Temperature log file URLs are constructed as:
+            `http://<beaglecam_ip>/mmc/tlog/<filename>`
+        """
+        payload = {
+            "cmd": 330,
+            "pro": "get_tlog",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_recording_params(self):
+        """
+        Example API Return:
+        {
+            "cmd":121,
+            "result":0,
+            "enable":0,
+            "record_duration":600,
+            "cover":1,
+            "chno":0,
+            "start_min":0,
+            "stop_min":59,
+            "start_hour":0,
+            "stop_hour":23
+        }
+        """
+        payload = {
+            "cmd": 121,
+            "pro": "get_rec_params",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_printer_settings(self):
+        """
+        Example API Return:
+        {
+            "cmd":340,
+            "result":0,
+            "feedrate":100,
+            "flowrate":100,
+            "zoffset":0
+        }
+        """
+        payload = {
+            "cmd": 340,
+            "pro": "get_pr_setting",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def start_print(self, filename: str):
+        """
+        Start a print job with the specified Gcode file.
+
+        Example API Return:
+        {
+            "cmd":313,
+            "result":301
+        }
+        """
+        payload = {
+            "cmd": 313,
+            "pro": "pr_start",
+            "filename": filename,
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def pause_print(self):
+        """
+        Pause the current print job.
+
+        Example API Return:
+        {
+            "cmd":314,
+            "result":0
+        }
+        """
+        payload = {
+            "cmd": 314,
+            "pro": "pr_pause",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def stop_print(self):
+        """
+        Stop the current print job.
+
+        Example API Return:
+        {
+            "cmd":317,
+            "result":0
+        }
+        """
+        payload = {
+            "cmd": 317,
+            "pro": "pr_off",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])
+
+    async def get_model_info(self, filename: str):
+        """
+        Example API Return:
+
+        {
+            "cmd":322,
+            "result":0,
+            "uploaded":"2025/07/22 09:10:22",
+            "size":180162,
+            "filamentTotalUsed":7624.959961,
+            "estimatedTotalTime":4657,
+            "layerHeight":0.300000,
+            "layerCount":3,
+            "height":1.100000
+        }
+        """
+        payload = {
+            "cmd": 322,
+            "pro": "get_model_info",
+            "filename": filename,
+            "user": self._username,
+            "pwd": self._password
+        }
+        return self._do_post(payload, payload["pro"])

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -48,7 +48,7 @@ class BeagleCamAPI:
 
             - result: 0 indicates success.
             - connect_state: 1 if connected.
-            - print_state: 102 indicates idle
+            - print_state: 102 indicates idle, 101 indicates printing, 103 indicates paused.
             - Other keys represent hardware status indicators.
         """
         payload = {
@@ -60,9 +60,9 @@ class BeagleCamAPI:
         return await self._do_post(payload, "connection_state")
 
     async def get_print_status(self):
-        """Poll printer status using cmd 318.
+        """Poll print job status using cmd 318.
         
-        API Example Return:
+        API Example Return (Idle):
         {
             "cmd": 318,
             "result": 0,
@@ -73,6 +73,19 @@ class BeagleCamAPI:
             "layerIndex": 0,
             "printingHeight": 0,
             "hadSize": 0
+        }
+
+        API Example Return (Printing):
+        {
+            "cmd":318,
+            "result":0,
+            "file_name":"Revised Kobo Clara Switch 2_0.05mm_PLA_MK3S_9m.gcode",
+            "progress":10,
+            "time_left":484,
+            "time_cost":52,
+            "layerIndex":3,
+            "printingHeight":0.300000,
+            "hadSize":40414
         }
         """
         payload = {

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -5,6 +5,15 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 
+PRINT_STATE_PRINTING = 101
+PRINT_STATE_IDLE = 102
+PRINT_STATE_PAUSED = 103
+
+PRINT_STATE = {
+    PRINT_STATE_PRINTING: "printing",
+    PRINT_STATE_IDLE: "idle",
+    PRINT_STATE_PAUSED: "paused",
+}
 
 class BeagleCamAPI:
     def __init__(self, ip: str, username: str, password: str, session: aiohttp.ClientSession):
@@ -28,6 +37,34 @@ class BeagleCamAPI:
             if self._call_counts[debug_key] % 10 == 0:
                 _LOGGER.debug("BeagleCamAPI.%s response: %s", debug_key, response_json)
             return response_json
+
+    async def check_user(self):
+        """
+        Example API Return:
+        {
+            "cmd":100,
+            "result":0,
+            "admin":1,
+            "modle":0,  # possibly a typo for "model"
+            "type":0
+        }
+
+        Example Invalid Login Return:
+        {
+            "cmd":100,
+            "result":-3,
+            "admin":1,
+            "modle":0,
+            "type":0
+        }
+        """
+        payload = {
+            "cmd": 100,
+            "pro": "check_user",
+            "user": self._username,
+            "pwd": self._password
+        }
+        return await self._do_post(payload, "check_user")
 
     async def get_connection_state(self):
         """

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -111,3 +111,43 @@ class BeagleCamAPI:
             if self._call_counts["temperature_status"] % 10 == 0:
                 _LOGGER.debug("BeagleCamAPI.get_temperature_status response: %s", responseJson)
             return responseJson
+
+    async def get_info(self):
+        """
+
+        API Example Return:
+        {
+            "cmd":101,
+            "result":0,
+            "p2pid":"....-######-.....",
+            "hardware":"Beagle V2",
+            "firmware":"1.2.9",
+            "mirror_mode":3,
+            "video_mode":0,
+            "online_num":0,
+            "network_type":"Wifi",
+            "macaddress":"2C:C3:E6:..:..:..",
+            "IPaddress":"192.168.###.###",
+            "netmask":"255.255.255.0",
+            "gateway":"192.168.###.1",
+            "dns1":"192.168.###.###",
+            "dns2":"192.168.###.###",
+            "dhcp":1,
+            "day_night_mode":0,
+            "alarm_voice":"default"
+            }
+        """
+        payload = {
+            "cmd": 101,
+            "pro": "info_get",
+            "user": self._username,
+            "pwd": self._password
+        }
+
+        async with self._session.post(self._url, json=payload) as response:
+            response.raise_for_status()
+            responseJson = await response.json()
+            self._call_counts["info_get"] += 1
+            if self._call_counts["info_get"] % 10 == 0:
+                _LOGGER.debug("BeagleCamAPI.info_get response: %s", responseJson)
+            return responseJson

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -8,11 +8,13 @@ _LOGGER = logging.getLogger(__name__)
 PRINT_STATE_PRINTING = 101
 PRINT_STATE_IDLE = 102
 PRINT_STATE_PAUSED = 103
+PRINT_STATE_COMPLETED = 105
 
 PRINT_STATE = {
     PRINT_STATE_PRINTING: "printing",
     PRINT_STATE_IDLE: "idle",
     PRINT_STATE_PAUSED: "paused",
+    PRINT_STATE_COMPLETED: "completed",
 }
 
 class BeagleCamAPI:
@@ -89,7 +91,7 @@ class BeagleCamAPI:
 
             - result: 0 indicates success.
             - connect_state: 1 if connected.
-            - print_state: 102 indicates idle, 101 indicates printing, 103 indicates paused.
+            - print_state: 102 indicates idle, 101 indicates printing, 103 indicates paused, 105 indicates completed.
             - Other keys represent hardware status indicators.
         """
         payload = {

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -5,6 +5,7 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 
+"""Constants representing print states from BeagleCam API."""
 PRINT_STATE_PRINTING = 101
 PRINT_STATE_IDLE = 102
 PRINT_STATE_PAUSED = 103
@@ -18,6 +19,14 @@ PRINT_STATE = {
 }
 
 class BeagleCamAPI:
+    """Client for interacting with the BeagleCam API.
+
+    All API calls are performed via HTTP POST requests to the /set3DPiCmd endpoint.
+
+    API calls were discovered by inspecting network traffic between the BeagleCam web application and the BeagleCam device.
+    As such, the API may not be officially documented and could change in future firmware updates. Plus we may have
+    missed specific status codes or parameters.
+    """
     def __init__(self, ip: str, username: str, password: str, session: aiohttp.ClientSession):
         self._url = f"http://{ip}/set3DPiCmd"
         self._username = username
@@ -249,6 +258,14 @@ class BeagleCamAPI:
 
     async def get_model(self):
         """
+        The get_model API call retrieves the list of supported 3D printer brands and models, and includes details for
+        all possible printer configurations. It also indicates the currently selected printer model and its specifications.
+
+        This API response is LONG and DETAILED. In practice, only the "selected" field is useful for determining the
+        current printer model, while the "BrandModelList" provides a comprehensive list of supported printers.
+
+        This BrandModelList was captured from a BeagleCam v2 device with firmware version 1.2.9 and may change in future updates.
+
         Example API Return:
         {
           "cmd": 253,

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -16,6 +16,7 @@ class BeagleCamAPI:
             "connection_state": 0,
             "print_status": 0,
             "temperature_status": 0,
+            "info_get": 0,
         }
 
     async def get_connection_state(self):

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -29,6 +29,10 @@ class BeagleCamAPI:
             "temperature_status": 0,
         })
 
+    @property
+    def closed(self) -> bool:
+        return self._session.closed
+
     async def _do_post(self, payload: dict, debug_key: str):
         async with self._session.post(self._url, json=payload) as response:
             response.raise_for_status()

--- a/custom_components/beaglecam/beaglecam_api.py
+++ b/custom_components/beaglecam/beaglecam_api.py
@@ -57,7 +57,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, "connection_state")
+        return await self._do_post(payload, "connection_state")
 
     async def get_print_status(self):
         """Poll printer status using cmd 318.
@@ -81,7 +81,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, "print_status")
+        return await self._do_post(payload, "print_status")
 
     async def get_temperature_status(self):
         """
@@ -102,7 +102,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, "temperature_status")
+        return await self._do_post(payload, "temperature_status")
 
     async def get_info(self):
         """
@@ -134,7 +134,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_baudrate(self):
         """
@@ -152,7 +152,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_tlv_params(self):
         """
@@ -189,7 +189,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_model(self):
         """
@@ -1109,7 +1109,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_osd(self):
         """
@@ -1126,7 +1126,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_video_mode(self):
         """
@@ -1143,7 +1143,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def update_check(self):
         """
@@ -1167,7 +1167,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_timelapse_videos(self):
         """
@@ -1196,7 +1196,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def connect_printer(self):
         """
@@ -1214,7 +1214,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def disconnect_printer(self):
         """
@@ -1232,7 +1232,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_print_files(self):
         """
@@ -1261,7 +1261,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_temperature_log(self):
         """
@@ -1298,7 +1298,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_recording_params(self):
         """
@@ -1322,7 +1322,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_printer_settings(self):
         """
@@ -1341,7 +1341,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def start_print(self, filename: str):
         """
@@ -1360,7 +1360,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def pause_print(self):
         """
@@ -1378,7 +1378,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def stop_print(self):
         """
@@ -1396,7 +1396,7 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])
 
     async def get_model_info(self, filename: str):
         """
@@ -1421,4 +1421,4 @@ class BeagleCamAPI:
             "user": self._username,
             "pwd": self._password
         }
-        return self._do_post(payload, payload["pro"])
+        return await self._do_post(payload, payload["pro"])

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -1,8 +1,8 @@
-from components.binary_sensor import BinarySensorEntity
-from config_entries import ConfigEntry
-from core import HomeAssistant
-from helpers.entity_platform import AddConfigEntryEntitiesCallback
-from helpers.update_coordinator import CoordinatorEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import BeagleCamDataUpdateCoordinator
 

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -1,8 +1,11 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .beaglecam_api import PRINT_STATE_PRINTING
 from .const import DOMAIN
 from .coordinator import BeagleCamDataUpdateCoordinator
 
@@ -44,9 +47,14 @@ class BeagleCamPrintingBinarySensor(CoordinatorEntity[BeagleCamDataUpdateCoordin
         if not (printer := self.coordinator.data["printer"]):
             return None
 
-        return self.available and bool(printer["print_state"] == 101)
+        return self.available and bool(printer["print_state"] == PRINT_STATE_PRINTING)
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data["printer"]["connect_state"] == 1
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return self.coordinator.device_info

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -18,8 +18,6 @@ async def async_setup_entry(
     ]["coordinator"]
     device_id = config_entry.unique_id
 
-    assert device_id is not None
-
     entities: list[BinarySensorEntity] = [
         BeagleCamPrintingBinarySensor(coordinator, device_id),
     ]

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -1,0 +1,52 @@
+from components.binary_sensor import BinarySensorEntity
+from config_entries import ConfigEntry
+from core import HomeAssistant
+from custom_components.beaglecam import BeagleCamDataUpdateCoordinator
+from helpers.entity_platform import AddConfigEntryEntitiesCallback
+from helpers.update_coordinator import CoordinatorEntity
+from .const import DOMAIN
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the available OctoPrint binary sensors."""
+    coordinator: BeagleCamDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]["coordinator"]
+    device_id = config_entry.unique_id
+
+    assert device_id is not None
+
+    entities: list[BinarySensorEntity] = [
+        BeagleCamPrintingBinarySensor(coordinator, device_id),
+    ]
+
+    async_add_entities(entities)
+
+class BeagleCamPrintingBinarySensor(CoordinatorEntity[BeagleCamDataUpdateCoordinator], BinarySensorEntity):
+    def __init__(
+            self,
+            coordinator: BeagleCamDataUpdateCoordinator,
+            device_id: str,
+    ) -> None:
+        """Initialize a new beaglecam printing sensor."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_name = "BeagleCam Printing"
+        self._attr_unique_id = f"printing-{device_id}"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def is_on(self):
+        """Return true if binary sensor is on."""
+        if not (printer := self.coordinator.data["printer"]):
+            return None
+
+        return self.available and bool(printer["print_state"] == 101)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]["connect_state"] == 1

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -4,10 +4,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from sensor import _is_printer_printing
 
 from .const import DOMAIN
 from .coordinator import BeagleCamDataUpdateCoordinator
+from .sensor import _is_printer_printing
 
 """Binary sensor platform for BeagleCam integration."""
 

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -36,7 +36,7 @@ class BeagleCamPrintingBinarySensor(CoordinatorEntity[BeagleCamDataUpdateCoordin
         self._device_id = device_id
         self._attr_name = "BeagleCam Printing"
         self._attr_unique_id = f"printing-{device_id}"
-        self._attr_device_info = coordinator.device_info
+        self._attr_device_info = coordinator.DeviceInfo
 
     @property
     def is_on(self):

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -39,7 +39,6 @@ class BeagleCamPrintingBinarySensor(CoordinatorEntity[BeagleCamDataUpdateCoordin
         self._device_id = device_id
         self._attr_name = "BeagleCam Printing"
         self._attr_unique_id = f"printing-{device_id}"
-        self._attr_device_info = coordinator.DeviceInfo
 
     @property
     def is_on(self):

--- a/custom_components/beaglecam/binary_sensor.py
+++ b/custom_components/beaglecam/binary_sensor.py
@@ -1,10 +1,11 @@
 from components.binary_sensor import BinarySensorEntity
 from config_entries import ConfigEntry
 from core import HomeAssistant
-from custom_components.beaglecam import BeagleCamDataUpdateCoordinator
 from helpers.entity_platform import AddConfigEntryEntitiesCallback
 from helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
+from .coordinator import BeagleCamDataUpdateCoordinator
+
 
 async def async_setup_entry(
         hass: HomeAssistant,
@@ -24,6 +25,7 @@ async def async_setup_entry(
     ]
 
     async_add_entities(entities)
+
 
 class BeagleCamPrintingBinarySensor(CoordinatorEntity[BeagleCamDataUpdateCoordinator], BinarySensorEntity):
     def __init__(

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -29,6 +29,7 @@ class BeagleCamCamera(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Camera)
     def __init__(self, hass: HomeAssistant, coordinator: BeagleCamDataUpdateCoordinator,
                  config_entry: ConfigEntry) -> None:
         super().__init__(coordinator)
+        Camera.__init__(self)
         self._attr_name = "BeagleCam Camera"
         self._attr_unique_id = config_entry.unique_id
         self._attr_brand = "Mintion"

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -1,31 +1,43 @@
 import logging
-
-from typing import Mapping, Any
-
 import yarl
+
 from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.template import Template
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import BeagleCamDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities):
-    async_add_entities([BeagleCamCamera(hass, entry.data, entry.entry_id)])
 
-class BeagleCamCamera(Camera):
-    def __init__(self, hass: HomeAssistant, device_info: Mapping[str, Any], identifier: str) -> None:
-        super().__init__()
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
+                            async_add_entities: AddConfigEntryEntitiesCallback):
+    coordinator: BeagleCamDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]["coordinator"]
+    async_add_entities([BeagleCamCamera(hass, coordinator, config_entry)])
+
+
+class BeagleCamCamera(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Camera):
+    def __init__(self, hass: HomeAssistant, coordinator: BeagleCamDataUpdateCoordinator,
+                 config_entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
         self._attr_name = "BeagleCam Camera"
-        self._attr_unique_id = identifier
+        self._attr_unique_id = config_entry.unique_id
         self._attr_brand = "Mintion"
-        self._attr_model = "BeagleCam v2"
-        self._username = device_info.get(CONF_USERNAME)
-        self._password = device_info.get(CONF_PASSWORD)
-        self._ip_address = Template(device_info.get(CONF_HOST), hass)
+        self._attr_model = coordinator.data["camera"]["model"]
+        self._username = config_entry.data.get(CONF_USERNAME)
+        self._password = config_entry.data.get(CONF_PASSWORD)
+        self._ip_address = Template(config_entry.data.get(CONF_HOST), hass)
         self._attr_supported_features = CameraEntityFeature.STREAM
-        self.stream_options["rtsp_transport"] = "TCP"
+        self.stream_options["rtsp_transport"] = "tcp"
 
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
@@ -59,3 +71,8 @@ class BeagleCamCamera(Camera):
         The BeagleCam does not support still images, so we return None.
         """
         return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return self.coordinator.device_info

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -1,5 +1,7 @@
+
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from propcache.api import cached_property
 from .const import DOMAIN
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -13,14 +15,18 @@ class BeagleCamCamera(CoordinatorEntity, Camera):
         self._attr_unique_id = "beaglecam_camera"
         self._attr_brand = "Mintion"
 
+    @cached_property
     def supported_features(self) -> CameraEntityFeature:
         return CameraEntityFeature.STREAM
 
+    @cached_property
     def stream_source(self) -> str | None:
         return self.coordinator.data.get("IPaddress", "unknown") % "rtsp://%s:554/0"
 
+    @cached_property
     def use_stream_for_stills(self) -> bool:
         return True
 
+    @cached_property
     def model(self) -> str | None:
         return self.coordinator.data.get("hardware", "unknown")

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -1,29 +1,60 @@
+import logging
+from typing import Mapping, Any
 
+import yarl
 from homeassistant.components.camera import Camera, CameraEntityFeature
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from propcache.api import cached_property
-from .const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.template import Template
+from .const import CONF_USERNAME, CONF_PASSWORD, CONF_IP
+
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([BeagleCamCamera(coordinator)])
+    async_add_entities([BeagleCamCamera(hass, entry.data, entry.entry_id)])
 
-class BeagleCamCamera(CoordinatorEntity, Camera):
-    def __init__(self, coordinator):
-        super().__init__(coordinator)
+class BeagleCamCamera(Camera):
+    def __init__(self, hass: HomeAssistant, device_info: Mapping[str, Any], identifier: str) -> None:
+        super().__init__()
         self._attr_name = "BeagleCam Camera"
-        self._attr_unique_id = "beaglecam_camera"
+        self._attr_unique_id = identifier
         self._attr_brand = "Mintion"
+        self._attr_model = "BeagleCam v2"
+        self._username = device_info.get(CONF_USERNAME)
+        self._password = device_info.get(CONF_PASSWORD)
+        self._ip_address = Template(device_info.get(CONF_IP), hass)
         self._attr_supported_features = CameraEntityFeature.STREAM
+        self.stream_options["rtsp_transport"] = "TCP"
 
-    @cached_property
     async def stream_source(self) -> str | None:
-        return self.coordinator.data.get("IPaddress", "unknown") % "rtsp://%s:554/0"
+        """Return the source of the stream."""
+        if self._ip_address is None:
+            return None
 
-    @cached_property
+        try:
+            stream_addr = self._ip_address.async_render(parse_result=False)
+            url = yarl.URL("rtsp://%s:554/0" % stream_addr)
+            if (
+                    not url.user
+                    and not url.password
+                    and self._username
+                    and self._password
+                    and url.is_absolute()
+            ):
+                url = url.with_user(self._username).with_password(self._password)
+            return str(url)
+        except TemplateError as err:
+            _LOGGER.error("Error parsing template %s: %s", self._ip_address, err)
+            return None
+
+    @property
     def use_stream_for_stills(self) -> bool:
         return True
 
-    @cached_property
-    def model(self) -> str | None:
-        return self.coordinator.data.get("hardware", "unknown")
+    async def async_camera_image(
+            self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
+        """
+        The BeagleCam does not support still images, so we return None.
+        """
+        return None

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -32,7 +32,7 @@ class BeagleCamCamera(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Camera)
         self._attr_name = "BeagleCam Camera"
         self._attr_unique_id = config_entry.unique_id
         self._attr_brand = "Mintion"
-        self._attr_model = coordinator.device_info.model
+        self._attr_model = coordinator.device_info.get("model", "BeagleCam")
         self._username = config_entry.data.get(CONF_USERNAME)
         self._password = config_entry.data.get(CONF_PASSWORD)
         self._ip_address = Template(config_entry.data.get(CONF_HOST), hass)

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -1,0 +1,26 @@
+from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .const import DOMAIN
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([BeagleCamCamera(coordinator)])
+
+class BeagleCamCamera(CoordinatorEntity, Camera):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_name = "BeagleCam Camera"
+        self._attr_unique_id = "beaglecam_camera"
+        self._attr_brand = "Mintion"
+
+    def supported_features(self) -> CameraEntityFeature:
+        return CameraEntityFeature.STREAM
+
+    def stream_source(self) -> str | None:
+        return self.coordinator.data.get("IPaddress", "unknown") % "rtsp://%s:554/0"
+
+    def use_stream_for_stills(self) -> bool:
+        return True
+
+    def model(self) -> str | None:
+        return self.coordinator.data.get("hardware", "unknown")

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -1,12 +1,14 @@
 import logging
+
 from typing import Mapping, Any
 
 import yarl
 from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.template import Template
-from .const import CONF_USERNAME, CONF_PASSWORD, CONF_IP
+from .const import CONF_USERNAME, CONF_PASSWORD
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +24,7 @@ class BeagleCamCamera(Camera):
         self._attr_model = "BeagleCam v2"
         self._username = device_info.get(CONF_USERNAME)
         self._password = device_info.get(CONF_PASSWORD)
-        self._ip_address = Template(device_info.get(CONF_IP), hass)
+        self._ip_address = Template(device_info.get(CONF_HOST), hass)
         self._attr_supported_features = CameraEntityFeature.STREAM
         self.stream_options["rtsp_transport"] = "TCP"
 

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -16,9 +16,11 @@ from .coordinator import BeagleCamDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+"""Camera entity representing the BeagleCam camera and its RTSP stream."""
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
                             async_add_entities: AddConfigEntryEntitiesCallback):
+    """Set up the BeagleCam camera based on a config entry."""
     coordinator: BeagleCamDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]["coordinator"]
@@ -26,6 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry,
 
 
 class BeagleCamCamera(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Camera):
+    """Representation of a BeagleCam camera."""
     def __init__(self, hass: HomeAssistant, coordinator: BeagleCamDataUpdateCoordinator,
                  config_entry: ConfigEntry) -> None:
         super().__init__(coordinator)
@@ -63,6 +66,7 @@ class BeagleCamCamera(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Camera)
 
     @property
     def use_stream_for_stills(self) -> bool:
+        """Return True, because BeagleCam does not support still images."""
         return True
 
     async def async_camera_image(

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -23,7 +23,7 @@ class BeagleCamCamera(Camera):
         self._attr_model = "BeagleCam v2"
         self._username = device_info.get(CONF_USERNAME)
         self._password = device_info.get(CONF_PASSWORD)
-        self._ip_address = Template(device_info.get(CONF_HOST), hass)
+        self._ip_address = Template(device_info.get(CONF_HOST), None)
         self._attr_supported_features = CameraEntityFeature.STREAM
         self.stream_options["rtsp_transport"] = "TCP"
 

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -14,13 +14,10 @@ class BeagleCamCamera(CoordinatorEntity, Camera):
         self._attr_name = "BeagleCam Camera"
         self._attr_unique_id = "beaglecam_camera"
         self._attr_brand = "Mintion"
+        self._attr_supported_features = CameraEntityFeature.STREAM
 
     @cached_property
-    def supported_features(self) -> CameraEntityFeature:
-        return CameraEntityFeature.STREAM
-
-    @cached_property
-    def stream_source(self) -> str | None:
+    async def stream_source(self) -> str | None:
         return self.coordinator.data.get("IPaddress", "unknown") % "rtsp://%s:554/0"
 
     @cached_property

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -4,11 +4,10 @@ from typing import Mapping, Any
 
 import yarl
 from homeassistant.components.camera import Camera, CameraEntityFeature
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.template import Template
-from .const import CONF_USERNAME, CONF_PASSWORD
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -32,7 +32,7 @@ class BeagleCamCamera(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Camera)
         self._attr_name = "BeagleCam Camera"
         self._attr_unique_id = config_entry.unique_id
         self._attr_brand = "Mintion"
-        self._attr_model = coordinator.data["camera"]["model"]
+        self._attr_model = coordinator.device_info.model
         self._username = config_entry.data.get(CONF_USERNAME)
         self._password = config_entry.data.get(CONF_PASSWORD)
         self._ip_address = Template(config_entry.data.get(CONF_HOST), hass)

--- a/custom_components/beaglecam/camera.py
+++ b/custom_components/beaglecam/camera.py
@@ -23,7 +23,7 @@ class BeagleCamCamera(Camera):
         self._attr_model = "BeagleCam v2"
         self._username = device_info.get(CONF_USERNAME)
         self._password = device_info.get(CONF_PASSWORD)
-        self._ip_address = Template(device_info.get(CONF_HOST), None)
+        self._ip_address = Template(device_info.get(CONF_HOST), hass)
         self._attr_supported_features = CameraEntityFeature.STREAM
         self.stream_options["rtsp_transport"] = "TCP"
 

--- a/custom_components/beaglecam/config_flow.py
+++ b/custom_components/beaglecam/config_flow.py
@@ -1,4 +1,3 @@
-from .beaglecam_api import BeagleCamAPI
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 import voluptuous as vol
@@ -6,6 +5,7 @@ import aiohttp
 import async_timeout
 import logging
 
+from .beaglecam_api import BeagleCamAPI
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/beaglecam/config_flow.py
+++ b/custom_components/beaglecam/config_flow.py
@@ -1,29 +1,30 @@
 from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
 import voluptuous as vol
 import aiohttp
 import async_timeout
 import logging
 
-from .const import DOMAIN, CONF_IP, CONF_USERNAME, CONF_PASSWORD
+from .const import DOMAIN, CONF_USERNAME, CONF_PASSWORD
 
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_IP): str,
+    vol.Required(CONF_HOST): str,
     vol.Required(CONF_USERNAME): str,
     vol.Required(CONF_PASSWORD): str,
 })
 
 async def validate_input(data):
-    ip = data[CONF_IP]
+    ip = data[CONF_HOST]
     username = data[CONF_USERNAME]
     password = data[CONF_PASSWORD]
     url = f"http://{ip}/set3DPiCmd"
 
     payload = {
-        "cmd": 312,
-        "pro": "get_prconnectstate",
+        "cmd": 100,
+        "pro": "check_user",
         "user": username,
         "pwd": password
     }
@@ -38,6 +39,8 @@ async def validate_input(data):
                     # You may want to verify a key in the JSON, like 'result': 'ok'
                     if "result" not in resp_json:
                         raise Exception("Unexpected response format")
+                    if resp_json["result"] != 0:
+                        raise Exception("Authentication failed")
     except Exception as e:
         _LOGGER.exception("Failed to connect to BeagleCam")
         raise

--- a/custom_components/beaglecam/config_flow.py
+++ b/custom_components/beaglecam/config_flow.py
@@ -1,4 +1,4 @@
-from custom_components.beaglecam import BeagleCamAPI
+from .beaglecam_api import BeagleCamAPI
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 import voluptuous as vol
@@ -15,6 +15,7 @@ DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): str,
     vol.Required(CONF_PASSWORD): str,
 })
+
 
 async def validate_input(data):
     ip = data[CONF_HOST]

--- a/custom_components/beaglecam/config_flow.py
+++ b/custom_components/beaglecam/config_flow.py
@@ -18,24 +18,25 @@ DATA_SCHEMA = vol.Schema({
 
 
 async def validate_input(data):
-    ip = data[CONF_HOST]
+    host = data[CONF_HOST]
     username = data[CONF_USERNAME]
     password = data[CONF_PASSWORD]
 
     try:
         async with aiohttp.ClientSession() as session:
             async with async_timeout.timeout(5):
-                api = BeagleCamAPI(ip, username, password, session)
+                api = BeagleCamAPI(host, username, password, session)
                 response = await api.check_user()
                 if "result" not in response:
                     raise Exception("Unexpected response format")
                 if response.get("result", None) != 0:
                     raise Exception("Authentication failed")
+                p2pid = (await api.get_info())["p2pid"]
     except Exception as e:
         _LOGGER.exception("Failed to connect to BeagleCam")
         raise
 
-    return {"title": f"BeagleCam @ {ip}"}
+    return {"title": f"BeagleCam @ {host}", "p2pid": p2pid}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -47,10 +48,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 info = await validate_input(user_input)
+                await self.async_set_unique_id(info["p2pid"])
+                self._abort_if_unique_id_configured(updates={CONF_HOST: user_input[CONF_HOST], CONF_USERNAME: user_input[CONF_USERNAME], CONF_PASSWORD: user_input[CONF_PASSWORD]})
                 return self.async_create_entry(title=info["title"], data=user_input)
-            except Exception:
+            except Exception as e:
                 return self.async_show_form(
-                    step_id="user", data_schema=DATA_SCHEMA, errors={"base": "cannot_connect"}
+                    step_id="user", data_schema=DATA_SCHEMA, errors={"base": str(e)}
                 )
 
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/custom_components/beaglecam/config_flow.py
+++ b/custom_components/beaglecam/config_flow.py
@@ -10,6 +10,8 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+"""Config flow for BeagleCam integration."""
+
 DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): str,
     vol.Required(CONF_USERNAME): str,

--- a/custom_components/beaglecam/const.py
+++ b/custom_components/beaglecam/const.py
@@ -4,3 +4,5 @@ DEFAULT_SCAN_INTERVAL = 10
 CONF_IP = "ip_address"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+
+SERVICE_PR_CONNECT = "pr_connect"

--- a/custom_components/beaglecam/const.py
+++ b/custom_components/beaglecam/const.py
@@ -1,7 +1,6 @@
 DOMAIN = "beaglecam"
 DEFAULT_SCAN_INTERVAL = 10
 
-CONF_IP = "ip_address"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 

--- a/custom_components/beaglecam/const.py
+++ b/custom_components/beaglecam/const.py
@@ -1,7 +1,4 @@
 DOMAIN = "beaglecam"
 DEFAULT_SCAN_INTERVAL = 10
 
-CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
-
 SERVICE_PR_CONNECT = "pr_connect"

--- a/custom_components/beaglecam/coordinator.py
+++ b/custom_components/beaglecam/coordinator.py
@@ -1,0 +1,98 @@
+import asyncio
+import logging
+from datetime import timedelta
+
+from aiohttp.web_exceptions import HTTPError
+
+from typing import cast
+from yarl import URL
+
+from homeassistant.config_entries import ConfigEntry
+from const import CONF_IP, DOMAIN, DEFAULT_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from .beaglecam_api import BeagleCamAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BeagleCamDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from the BeagleCam API"""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+            self,
+            hass: HomeAssistant,
+            beaglecam: BeagleCamAPI,
+            config_entry: ConfigEntry,
+            interval: int = DEFAULT_SCAN_INTERVAL,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"beaglecam-{config_entry.entry_id}",
+            update_interval=timedelta(seconds=interval),
+        )
+        self._beaglecam = beaglecam
+        self._printer_offline = False
+        self.data = {"camera": None, "printer": None, "job": None, "last_read_time": None}
+
+    async def async_update_data(self):
+        try:
+            try:
+                connection = await self._beaglecam.get_connection_state()
+            except Exception as err:
+                _LOGGER.debug("BeagleCam is offline. Polling again in 300s.")
+                await asyncio.sleep(300)  # throttle manually
+                return None
+
+            # Printer is online – proceed with normal status polling
+            print_status = await self._beaglecam.get_print_status()
+            temp_status = await self._beaglecam.get_temperature_status()
+
+            # Merge API responses
+            combined = {
+                **{k: v for k, v in print_status.items() if k != "cmd"},
+                **{k: v for k, v in temp_status.items() if k != "cmd"},
+                **{k: v for k, v in connection.items() if k not in ("cmd", "result")},
+            }
+
+            _LOGGER.debug("Combined BeagleCam data: %s", combined)
+            return combined
+            # return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}
+
+        except HTTPError as httperr:
+            _LOGGER.warning("BeagleCam HTTP error: %s status: %s reason: %s", httperr, httperr.status, httperr.reason)
+            raise UpdateFailed(f"Data fetch failed: {httperr}") from httperr
+        except Exception as err:
+            _LOGGER.warning("BeagleCam polling error: %s", err)
+            raise UpdateFailed(f"Data fetch failed: {err}") from err
+
+    async def _async_setup(self) -> None:
+        """Set up the coordinator.
+        """
+        try:
+            self.data["camera"] = await self._beaglecam.get_info()
+        except HTTPError as httperr:
+            _LOGGER.warning("BeagleCam HTTP error: %s status: %s reason: %s", httperr, httperr.status, httperr.reason)
+            raise UpdateFailed(f"Data fetch failed: {httperr}") from httperr
+        except Exception as err:
+            _LOGGER.warning("BeagleCam polling error: %s", err)
+            raise UpdateFailed(f"Data fetch failed: {err}") from err
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Device info."""
+        unique_id = cast(str, self.config_entry.unique_id)
+        configuration_url = URL.build(scheme="http", host=self.config_entry.data[CONF_IP])
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            manufacturer="Mintion",
+            name=self.data["camera"].get('hardware', 'BeagleCam'),
+            configuration_url=str(configuration_url),
+        )

--- a/custom_components/beaglecam/coordinator.py
+++ b/custom_components/beaglecam/coordinator.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 from aiohttp.web_exceptions import HTTPError
 
-from typing import cast
 from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
@@ -90,12 +89,12 @@ class BeagleCamDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def device_info(self) -> DeviceInfo:
         """Device info."""
-        unique_id = self.data["camera"].get("p2pid", cast(str, self.config_entry.unique_id))
         configuration_url = URL.build(scheme="http", host=self.config_entry.data[CONF_HOST])
 
         return DeviceInfo(
-            identifiers={(DOMAIN, unique_id)},
+            identifiers={(DOMAIN, self.config_entry.unique_id)},
             manufacturer="Mintion",
-            name=self.data["camera"].get('hardware', 'BeagleCam'),
+            name=self.data.get("camera", {}).get('hardware', 'BeagleCam'),
             configuration_url=str(configuration_url),
+            model=self.data.get("camera", {}).get('hardware', 'BeagleCam'),
         )

--- a/custom_components/beaglecam/coordinator.py
+++ b/custom_components/beaglecam/coordinator.py
@@ -43,7 +43,7 @@ class BeagleCamDataUpdateCoordinator(DataUpdateCoordinator):
         self._printer_offline = False
         self.data = {"camera": None, "printer": None, "job": None, "last_read_time": None}
 
-    async def async_update_data(self):
+    async def _async_update_data(self):
         try:
             try:
                 connection = await self._beaglecam.get_connection_state()

--- a/custom_components/beaglecam/coordinator.py
+++ b/custom_components/beaglecam/coordinator.py
@@ -8,12 +8,13 @@ from typing import cast
 from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
-from const import CONF_IP, DOMAIN, DEFAULT_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_HOST
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt
 from .beaglecam_api import BeagleCamAPI
+from .const import DOMAIN, DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ class BeagleCamDataUpdateCoordinator(DataUpdateCoordinator):
     def device_info(self) -> DeviceInfo:
         """Device info."""
         unique_id = self.data["camera"].get("p2pid", cast(str, self.config_entry.unique_id))
-        configuration_url = URL.build(scheme="http", host=self.config_entry.data[CONF_IP])
+        configuration_url = URL.build(scheme="http", host=self.config_entry.data[CONF_HOST])
 
         return DeviceInfo(
             identifiers={(DOMAIN, unique_id)},

--- a/custom_components/beaglecam/coordinator.py
+++ b/custom_components/beaglecam/coordinator.py
@@ -17,9 +17,17 @@ from .const import DOMAIN, DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
+"""Data update coordinator for BeagleCam integration."""
 
 class BeagleCamDataUpdateCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching data from the BeagleCam API"""
+    """Class to manage fetching data from the BeagleCam API
+
+    Data is fetched once per refresh interval and stored in self.data as a dictionary with keys:
+    - "camera": Camera information
+    - "printer": Printer status information
+    - "job": Current print job information
+    - "last_read_time": Timestamp of the last successful data fetch
+    """
 
     config_entry: ConfigEntry
 

--- a/custom_components/beaglecam/coordinator.py
+++ b/custom_components/beaglecam/coordinator.py
@@ -57,14 +57,15 @@ class BeagleCamDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Merge API responses
             printer_state = {
-                **{k: v for k, v in temp_status.items() if k != "cmd"},
+                **{k: v for k, v in temp_status.items() if k not in ("cmd", "result")},
                 **{k: v for k, v in connection.items() if k not in ("cmd", "result")},
             }
             job_state = {
-                ** {k: v for k, v in print_status.items() if k != "cmd"}
+                ** {k: v for k, v in print_status.items() if k not in ("cmd", "result")},
             }
 
             _LOGGER.debug("Combined BeagleCam data: %s", printer_state)
+            _LOGGER.debug("Combined BeagleCam Job data: %s", job_state)
             return {"job": job_state, "printer": printer_state, "last_read_time": dt.utcnow()}
 
         except HTTPError as httperr:

--- a/custom_components/beaglecam/manifest.json
+++ b/custom_components/beaglecam/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "beaglecam",
   "name": "BeagleCam Printer Camera",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "documentation": "https://github.com/jgrant216/ha-beaglecam",
   "dependencies": [],
   "codeowners": [

--- a/custom_components/beaglecam/manifest.json
+++ b/custom_components/beaglecam/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/jgrant216/ha-beaglecam",
   "dependencies": [],
   "codeowners": [
-    "@jgrant216"
+    "@jgrant216", "@epowell"
   ],
   "config_flow": true,
   "iot_class": "local_polling",

--- a/custom_components/beaglecam/manifest.json
+++ b/custom_components/beaglecam/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "beaglecam",
   "name": "BeagleCam Printer Camera",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "documentation": "https://github.com/jgrant216/ha-beaglecam",
   "dependencies": [],
   "codeowners": [

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -177,6 +177,7 @@ class BeagleCamTemperatureSensor(BeagleCamSensorBase):
         super().__init__(coordinator, f"{temp_type} {tool} temp", device_id)
         self._temp_type = temp_type
         self._api_tool = tool
+        self.key = ("des_" if self._temp_type == "target" else "") + "tempture_" + self._api_tool[0:3]
 
     @property
     def native_value(self):
@@ -185,9 +186,8 @@ class BeagleCamTemperatureSensor(BeagleCamSensorBase):
             return None
 
         # Determine the key to look for based on temp_type and tool
-        key = "des_" if self._temp_type == "target" else "" + "tempture_" + self._api_tool[0:3]
-        _LOGGER.debug("Fetching temperature for key: %s", key)
-        return round(printer.get(key, None), 2) if printer.get(key, None) is not None else None
+        _LOGGER.debug("Fetching temperature for key: %s", self.key)
+        return round(printer.get(self.key, None), 2) if printer.get(self.key, None) is not None else None
 
     @property
     def available(self) -> bool:

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -52,7 +52,7 @@ class BeagleCamSensorBase(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Sen
         self._device_id = device_id
         self._attr_name = f"BeagleCam {sensor_type}"
         self._attr_unique_id = f"{sensor_type}-{device_id}"
-        self._attr_device_info = coordinator.device_info
+        self._attr_device_info = coordinator.DeviceInfo
 
 
 class BeagleCamStatusSensor(BeagleCamSensorBase):

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -1,25 +1,211 @@
+from datetime import datetime, timedelta
+
+from beaglecam_api import PRINT_STATE, PRINT_STATE_PRINTING
+from components.sensor import SensorDeviceClass, SensorStateClass
+from config_entries import ConfigEntry
+from core import HomeAssistant
+from helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
+from .coordinator import BeagleCamDataUpdateCoordinator
 
-async def async_setup_entry(hass, entry, async_add_entities):
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([BeagleCamStatusSensor(coordinator)])
 
-class BeagleCamStatusSensor(CoordinatorEntity, SensorEntity):
-    def __init__(self, coordinator):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback):
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    device_id = entry.unique_id
+
+    assert device_id is not None
+    entities: list[SensorEntity] = \
+        [BeagleCamTemperatureSensor(coordinator, tool, sensor_type, device_id) for tool in ("nozzle", "bed") for sensor_type in ("actual", "target")] + \
+        [
+            BeagleCamStatusSensor(coordinator, device_id),
+            BeagleCamJobPercentageSensor(coordinator, device_id),
+            BeagleCamFileNameSensor(coordinator, device_id),
+            BeagleCamStartTimeSensor(coordinator, device_id),
+            BeagleCamEstimatedFinishTimeSensor(coordinator, device_id),
+        ]
+    async_add_entities(entities)
+
+
+def _is_printer_printing(printer: dict) -> bool:
+    return (
+            printer
+            and printer["print_state"]
+            and printer["print_state"] == PRINT_STATE_PRINTING
+    )
+
+
+class BeagleCamSensorBase(CoordinatorEntity[BeagleCamDataUpdateCoordinator], SensorEntity):
+    """Representation of a BeagleCam sensor."""
+
+    def __init__(
+            self,
+            coordinator: BeagleCamDataUpdateCoordinator,
+            sensor_type: str,
+            device_id: str,
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
         super().__init__(coordinator)
-        self._attr_name = "BeagleCam Print Status"
-        self._attr_unique_id = "beaglecam_print_status"
+        self._device_id = device_id
+        self._attr_name = f"BeagleCam {sensor_type}"
+        self._attr_unique_id = f"{sensor_type}-{device_id}"
+        self._attr_device_info = coordinator.device_info
+
+
+class BeagleCamStatusSensor(BeagleCamSensorBase):
+    _attr_icon = "mdi:printer-3d"
+
+    def __init__(
+            self, coordinator: BeagleCamDataUpdateCoordinator, device_id: str
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
+        super().__init__(coordinator, "Current State", device_id)
 
     @property
-    def state(self):
-        # Choose a representative value (e.g., progress or status)
-        if not hasattr(self, "coordinator") or not getattr(self.coordinator, "data", None):
-            return "unknown"
-        return self.coordinator.data.get("progress", "unknown")
+    def native_value(self):
+        """Return sensor state."""
+        printer = self.coordinator.data.get("printer", None)
+        if not printer or not printer.get("print_state", None):
+            return None
+
+        return PRINT_STATE[printer["print_state"]]
 
     @property
-    def extra_state_attributes(self):
-        # Return the full response as attributes
-        return getattr(self.coordinator, "data", {})
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+
+
+class BeagleCamJobPercentageSensor(BeagleCamSensorBase):
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_icon = "mdi:file-percent"
+
+    def __init__(
+            self, coordinator: BeagleCamDataUpdateCoordinator, device_id: str
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
+        super().__init__(coordinator, "Job Percentage", device_id)
+
+    @property
+    def native_value(self):
+        """Return sensor state."""
+        job = self.coordinator.data.get("job", None)
+        if not job:
+            return None
+
+        if not (state := job.get("progress", None)):
+            return 0
+
+        return round(state, 2)
+
+
+class BeagleCamEstimatedFinishTimeSensor(BeagleCamSensorBase):
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(
+            self, coordinator: BeagleCamDataUpdateCoordinator, device_id: str
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
+        super().__init__(coordinator, "Job Estimated Finish Time", device_id)
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return sensor state."""
+        job = self.coordinator.data.get("job", None)
+        if not job \
+                or not (time_left := job.get("time_left", None)) \
+                or not _is_printer_printing(self.coordinator.data["printer"]):
+            return None
+
+        read_time = self.coordinator.data["last_read_time"]
+
+        return (read_time + timedelta(seconds=time_left)).replace(
+            second=0
+        )
+
+
+class BeagleCamStartTimeSensor(BeagleCamSensorBase):
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(
+            self, coordinator: BeagleCamDataUpdateCoordinator, device_id: str
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
+        super().__init__(coordinator, "Job Start Time", device_id)
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return sensor state."""
+        job = self.coordinator.data.get("job", None)
+        if not job \
+                or not (time_cost := job.get("time_cost", None)) \
+                or not _is_printer_printing(self.coordinator.data["printer"]):
+            return None
+
+        read_time = self.coordinator.data["last_read_time"]
+
+        return (read_time - timedelta(seconds=time_cost)).replace(
+            second=0
+        )
+
+
+class BeagleCamTemperatureSensor(BeagleCamSensorBase):
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+            self,
+            coordinator: BeagleCamDataUpdateCoordinator,
+            tool: str,  # e.g., "nozzle", "bed"
+            temp_type: str,  # "actual" or "target"
+            device_id: str,
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
+        super().__init__(coordinator, f"{temp_type} {tool} temp", device_id)
+        self._temp_type = temp_type
+        self._api_tool = tool
+
+    @property
+    def native_value(self):
+        printer = self.coordinator.data.get("printer", None)
+        if not printer:
+            return None
+
+        # Determine the key to look for based on temp_type and tool
+        key = "des_" if self._temp_type == "target" else "" + "tempture_" + self._api_tool[0:3]
+        return round(printer.get(key, None), 2) if printer.get(key, None) is not None else None
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.data["printer"]
+
+
+class BeagleCamFileNameSensor(BeagleCamSensorBase):
+
+    def __init__(
+            self,
+            coordinator: BeagleCamDataUpdateCoordinator,
+            device_id: str,
+    ) -> None:
+        """Initialize a new BeagleCam sensor."""
+        super().__init__(coordinator, "Current File", device_id)
+
+    @property
+    def native_value(self) -> str | None:
+        """Return sensor state."""
+        job = self.coordinator.data.get("job", None)
+
+        return job.get("file_name", None)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.last_update_success:
+            return False
+        job = self.coordinator.data.get("job", None)
+        return job and "file_name" in job
+

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -1,24 +1,26 @@
 from datetime import datetime, timedelta
 
-from beaglecam_api import PRINT_STATE, PRINT_STATE_PRINTING
-from components.sensor import SensorDeviceClass, SensorStateClass
-from config_entries import ConfigEntry
-from core import HomeAssistant
-from helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .beaglecam_api import PRINT_STATE, PRINT_STATE_PRINTING
 from .const import DOMAIN
 from .coordinator import BeagleCamDataUpdateCoordinator
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddConfigEntryEntitiesCallback):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
+                            async_add_entities: AddConfigEntryEntitiesCallback):
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     device_id = entry.unique_id
 
     assert device_id is not None
     entities: list[SensorEntity] = \
-        [BeagleCamTemperatureSensor(coordinator, tool, sensor_type, device_id) for tool in ("nozzle", "bed") for sensor_type in ("actual", "target")] + \
+        [BeagleCamTemperatureSensor(coordinator, tool, sensor_type, device_id) for tool in ("nozzle", "bed") for
+         sensor_type in ("actual", "target")] + \
         [
             BeagleCamStatusSensor(coordinator, device_id),
             BeagleCamJobPercentageSensor(coordinator, device_id),
@@ -208,4 +210,3 @@ class BeagleCamFileNameSensor(BeagleCamSensorBase):
             return False
         job = self.coordinator.data.get("job", None)
         return job and "file_name" in job
-

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -14,7 +14,7 @@ from .coordinator import BeagleCamDataUpdateCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
                             async_add_entities: AddConfigEntryEntitiesCallback):
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator: BeagleCamDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     device_id = entry.unique_id
 
     entities: list[SensorEntity] = \
@@ -52,7 +52,6 @@ class BeagleCamSensorBase(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Sen
         self._device_id = device_id
         self._attr_name = f"BeagleCam {sensor_type}"
         self._attr_unique_id = f"{sensor_type}-{device_id}"
-        self._attr_device_info = coordinator.DeviceInfo
 
 
 class BeagleCamStatusSensor(BeagleCamSensorBase):

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -1,15 +1,20 @@
+import logging
 from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from .beaglecam_api import PRINT_STATE, PRINT_STATE_PRINTING
 from .const import DOMAIN
 from .coordinator import BeagleCamDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
@@ -52,6 +57,11 @@ class BeagleCamSensorBase(CoordinatorEntity[BeagleCamDataUpdateCoordinator], Sen
         self._device_id = device_id
         self._attr_name = f"BeagleCam {sensor_type}"
         self._attr_unique_id = f"{sensor_type}-{device_id}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return self.coordinator.device_info
 
 
 class BeagleCamStatusSensor(BeagleCamSensorBase):
@@ -176,6 +186,7 @@ class BeagleCamTemperatureSensor(BeagleCamSensorBase):
 
         # Determine the key to look for based on temp_type and tool
         key = "des_" if self._temp_type == "target" else "" + "tempture_" + self._api_tool[0:3]
+        _LOGGER.debug("Fetching temperature for key: %s", key)
         return round(printer.get(key, None), 2) if printer.get(key, None) is not None else None
 
     @property

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -17,7 +17,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry,
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     device_id = entry.unique_id
 
-    assert device_id is not None
     entities: list[SensorEntity] = \
         [BeagleCamTemperatureSensor(coordinator, tool, sensor_type, device_id) for tool in ("nozzle", "bed") for
          sensor_type in ("actual", "target")] + \

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -177,6 +177,7 @@ class BeagleCamTemperatureSensor(BeagleCamSensorBase):
         super().__init__(coordinator, f"{temp_type} {tool} temp", device_id)
         self._temp_type = temp_type
         self._api_tool = tool
+        # Determine the key to look for based on temp_type and tool
         self.key = ("des_" if self._temp_type == "target" else "") + "tempture_" + self._api_tool[0:3]
 
     @property
@@ -185,8 +186,6 @@ class BeagleCamTemperatureSensor(BeagleCamSensorBase):
         if not printer:
             return None
 
-        # Determine the key to look for based on temp_type and tool
-        _LOGGER.debug("Fetching temperature for key: %s", self.key)
         return round(printer.get(self.key, None), 2) if printer.get(self.key, None) is not None else None
 
     @property

--- a/custom_components/beaglecam/sensor.py
+++ b/custom_components/beaglecam/sensor.py
@@ -165,6 +165,8 @@ class BeagleCamTemperatureSensor(BeagleCamSensorBase):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_suggested_display_precision = 0
 
     def __init__(
             self,

--- a/hacs.json
+++ b/hacs.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/jgrant216/ha-beaglecam",
   "codeowners": ["@jgrant216", "@epowell"],
   "requirements": [],
-  "version": "0.2.0",
+  "version": "0.1.0",
   "content_in_root": false
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,8 +2,8 @@
   "name": "BeagleCam",
   "domain": "beaglecam",
   "documentation": "https://github.com/jgrant216/ha-beaglecam",
-  "codeowners": ["@jgrant216"],
+  "codeowners": ["@jgrant216", "@epowell"],
   "requirements": [],
-  "version": "0.1.0",
+  "version": "0.2.0",
   "content_in_root": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-beaglecam",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-beaglecam",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "dependencies": {
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
Addresses issue #2 .

This PR includes:

- Revamp of the existing plugin to resemble the current Octoprint plugin state.
    - Standardization of config data with recommended existing developer guidelines
    - Many sensor entities analogous to Octoprint's, including a binary sensor and states/temperatures.
- Addition of a Camera entity source from the BeagleCam's RTSP stream
- Completion of the beaglecam_api with example responses - or at least every API call I could find in the UI.
    - Most are unused, but ready for expansion

The plugin in this state has been fairly robust under manual testing. I have tested:
- Reloading the integration while live.
- Many cycles of remove/add
- Incorrect credentials
- Full print cycles
- Print cancellations

However, I have only tested with my BeagleCam v2, and have no way of knowing if this will work with V1 or V3.

Futures:
- Support for two distinct devices - the printer itself, and the beaglecam. We have lots of printer configuration information from the BeagleCam's configuration!
- More fun sensors from the rest of the API
- Buttons/etc to control the camera, show files/media, pull timelapses...